### PR TITLE
Add GitHub Actions for Expo EAS build and updates

### DIFF
--- a/.github/workflows/build-on-master.yml
+++ b/.github/workflows/build-on-master.yml
@@ -1,0 +1,19 @@
+name: EAS Build on Master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_ios:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install -g eas-cli
+      - run: eas build -p ios --profile preview --non-interactive
+        env:
+          EAS_ACCESS_TOKEN: ${{ secrets.EAS_ACCESS_TOKEN }}

--- a/.github/workflows/manual-mobile-release.yml
+++ b/.github/workflows/manual-mobile-release.yml
@@ -1,0 +1,35 @@
+name: Manual Mobile Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_type:
+        description: 'Type of deployment: ota or build'
+        required: true
+        type: choice
+        options:
+          - ota
+          - build
+      release_channel:
+        description: 'Release channel or profile name'
+        required: false
+        default: 'preview'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install -g eas-cli
+      - name: Run selected command
+        env:
+          EAS_ACCESS_TOKEN: ${{ secrets.EAS_ACCESS_TOKEN }}
+        run: |
+          if [ "${{ github.event.inputs.deploy_type }}" = "ota" ]; then
+            eas update --branch ${{ github.event.inputs.release_channel }} --non-interactive
+          else
+            eas build -p ios --profile ${{ github.event.inputs.release_channel }} --non-interactive
+          fi


### PR DESCRIPTION
## Summary
- add workflow to automatically build on push to master
- add manual workflow to trigger EAS OTA or build

## Testing
- `npm test` *(fails: Missing script)*